### PR TITLE
Fixes exception due to ast parser changes.

### DIFF
--- a/find_tests.py
+++ b/find_tests.py
@@ -184,6 +184,9 @@ class PqlSchemaAwareTestCase(BasePqlTestCase):
     def test_sanity(self):
         self.compare('a == 3', {'a': 3})
 
+    def test_minus(self):
+        self.compare('a == -1', {'a': -1})
+
     def test_invalid_field(self):
         with self.assertRaises(pql.ParseError) as context:
             self.compare('b == 3', None)

--- a/find_tests.py
+++ b/find_tests.py
@@ -17,6 +17,9 @@ class PqlSchemaLessTestCase(BasePqlTestCase):
     def test_equal_int(self):
         self.compare('a == 1', {'a': 1})
 
+    def test_plus_operator(self):
+        self.compare('a == +1', {'a': 1})
+
     def test_minus(self):
         self.compare('a == -1', {'a': -1})
 

--- a/find_tests.py
+++ b/find_tests.py
@@ -185,6 +185,10 @@ class PqlSchemaLessTestCase(BasePqlTestCase):
                           {'$geoWithin':
                            {'$' + shape: [[1, 2], [3, 4], [5, 6]]}}})
 
+    def test_symver(self):
+        self.compare('version == symver("1.0.0 (0)")', {'version': 1000000000.0})
+
+
 class PqlSchemaAwareTestCase(BasePqlTestCase):
 
     def compare(self, string, expected):

--- a/find_tests.py
+++ b/find_tests.py
@@ -17,6 +17,15 @@ class PqlSchemaLessTestCase(BasePqlTestCase):
     def test_equal_int(self):
         self.compare('a == 1', {'a': 1})
 
+    def test_minus(self):
+        self.compare('a == -1', {'a': -1})
+
+    def test_more_than_minus(self):
+        self.compare('a > -1', {'a': {'$gt': -1}})
+
+    def test_less_than_minus(self):
+        self.compare('a < -1', {'a': {'$lt': -1}})
+
     def test_not_equal_string(self):
         self.compare('a != "foo"', {'a': {'$ne': 'foo'}})
 

--- a/pql/matching.py
+++ b/pql/matching.py
@@ -375,9 +375,8 @@ class IntField(AlgebricField):
         return node.value
     def handle_Num(self, node):
         return node.n
-
     def handle_UnaryOp(self, node):
-        if (node.op.__class__.__name__ == 'USub'):
+        if (type(node.op) == ast.USub):
             return - node.operand.value
         else:
             raise NotImplementedError()

--- a/pql/matching.py
+++ b/pql/matching.py
@@ -376,10 +376,11 @@ class IntField(AlgebricField):
     def handle_Num(self, node):
         return node.n
     def handle_UnaryOp(self, node):
-        if (type(node.op) == ast.USub):
+        op_type = type(node.op)
+        if (op_type == ast.USub):
             return - node.operand.value
         else:
-            raise NotImplementedError()
+            return node.operand.value
 
     def handle_Call(self, node):
         return IntFunc().handle(node)

--- a/pql/matching.py
+++ b/pql/matching.py
@@ -375,6 +375,13 @@ class IntField(AlgebricField):
         return node.value
     def handle_Num(self, node):
         return node.n
+
+    def handle_UnaryOp(self, node):
+        if (node.op.__class__.__name__ == 'USub'):
+            return - node.operand.value
+        else:
+            raise NotImplementedError()
+
     def handle_Call(self, node):
         return IntFunc().handle(node)
 

--- a/pql/matching.py
+++ b/pql/matching.py
@@ -111,6 +111,8 @@ class SchemaAwareParser(Parser):
         super(SchemaAwareParser, self).__init__(SchemaAwareOperatorMap(*a, **k))
 
 class FieldName(AstHandler):
+    def handle_Constant(self, node):
+        return node.value
     def handle_Str(self, node):
         return node.s
     def handle_Name(self, name):
@@ -338,7 +340,7 @@ class Field(AstHandler):
     SPECIAL_VALUES = {'None': None,
                       'null': None}
 
-    def handle_NameConstant(self,node):
+    def handle_Constant(self, node):
         try:
             return self.SPECIAL_VALUES[str(node.value)]
         except KeyError:
@@ -365,8 +367,12 @@ class StringField(AlgebricField):
         return StringFunc().handle(node)
     def handle_Str(self, node):
         return node.s
+    def handle_Constant(self, node):
+        return node.value
 
 class IntField(AlgebricField):
+    def handle_Constant(self, node):
+        return node.value
     def handle_Num(self, node):
         return node.n
     def handle_Call(self, node):
@@ -395,6 +401,8 @@ class DictField(Field):
                     for key, value in zip(node.keys, node.values))
 
 class DateTimeField(AlgebricField):
+    def handle_Constant(self, node):
+        return parse_date(node.s)
     def handle_Str(self, node):
         return parse_date(node)
     def handle_Num(self, node):

--- a/pql/matching.py
+++ b/pql/matching.py
@@ -454,10 +454,7 @@ class SymverField(AlgebricField):
     re_version = r'(\d+)\.(\d+)\.(\d+)\s*\((\d+)\)'
 
     def handle_Constant(self, node):
-        print(self.re_version)
-        print(node.value)
         d = re.findall(self.re_version, node.value)[0]
-        print(d)
         return (int(d[0]) * 1e9) + (int(d[1]) * 1e6) + (int(d[2]) * 1e3) + int(d[3])
 
     def handle_Num(self, node):

--- a/pql/matching.py
+++ b/pql/matching.py
@@ -402,7 +402,7 @@ class DictField(Field):
 
 class DateTimeField(AlgebricField):
     def handle_Constant(self, node):
-        return parse_date(node.s)
+        return parse_date(node.value)
     def handle_Str(self, node):
         return parse_date(node)
     def handle_Num(self, node):
@@ -411,6 +411,8 @@ class DateTimeField(AlgebricField):
         return DateTimeFunc().handle(node)
 
 class EpochField(AlgebricField):
+    def handle_Constant(self, node):
+        return float(parse_date(node).strftime('%s.%f'))
     def handle_Str(self, node):
         return float(parse_date(node).strftime('%s.%f'))
     def handle_Num(self, node):
@@ -419,6 +421,8 @@ class EpochField(AlgebricField):
         return EpochFunc().handle(node)
 
 class EpochUTCField(AlgebricField):
+    def handle_Constant(self, node):
+        return timegm(parse_date(node).timetuple())
     def handle_Str(self, node):
         return timegm(parse_date(node).timetuple())
     def handle_Num(self, node):
@@ -427,6 +431,8 @@ class EpochUTCField(AlgebricField):
         return EpochUTCFunc().handle(node)
 
 class IdField(AlgebricField):
+    def handle_Constant(self, node):
+        return bson.ObjectId(node.value)
     def handle_Str(self, node):
         return bson.ObjectId(node.s)
     def handle_Call(self, node):

--- a/pql/matching.py
+++ b/pql/matching.py
@@ -26,10 +26,10 @@ from calendar import timegm
 
 
 def parse_date(node):
-    if hasattr(node, 'n'): # it's a number!
+    if type(node.value) in (int, float): # it's a number!
         return datetime.datetime.fromtimestamp(node.n)
     try:
-        return dateutil.parser.parse(node.s)
+        return dateutil.parser.parse(node.value)
     except Exception as e:
         raise ParseError('Error parsing date: ' + str(e), col_offset=node.col_offset)
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 
 setup(name='pql',
       version=__version__,
@@ -12,6 +12,9 @@ setup(name='pql',
                      "Intended Audience :: Developers",
                      "Programming Language :: Python :: 3.3",
                      "Programming Language :: Python :: 3.5",
+                     "Programming Language :: Python :: 3.6",
+                     "Programming Language :: Python :: 3.7",
+                     "Programming Language :: Python :: 3.8",
                      "Operating System :: POSIX :: Linux",
                      "Operating System :: MacOS :: MacOS X"],
       license='BSD',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = py33,py35
+envlist = py{py3,27,35,36,37,38}
+skip_missing_interpreters = true
+
 [testenv]
 deps=nose
 commands=nosetests


### PR DESCRIPTION
I just wrote quick fix of #29 by producing `handle_Constant()` method for each AstHandlers.
And the existing `handle_Num()`, `handle_Str()`, .. methods were left untouched to obtain backward compatibility.

See https://docs.python.org/3/library/ast.html#ast.NodeVisitor.generic_visit

> since version 3.8: Methods visit_Num(), visit_Str(), visit_Bytes(), visit_NameConstant() and visit_Ellipsis() are deprecated now and will not be called in future Python versions. Add the visit_Constant() method to handle all constant nodes.
