### PR TITLE
adding constant handler for comaptibality of pql with python versions > 3.7

### DIFF
--- a/pql/matching.py
+++ b/pql/matching.py
@@ -369,7 +369,8 @@ class StringField(AlgebricField):
 
 class ConstantField(AlgebricField):  
     """
-    Converting constants into a string (ast parser assigns a value of "Constant" to quoted strings and constant numeric values to the right
+    Converting constants into a string 
+    (ast parser assigns a value of "Constant" to quoted strings and constant numeric values to the right
     and lef part of comparison expression(comparison operators). for handling these constants we convert this constant into a string.
     adding a ConsatntField handler class which we pass in a GenericField class)
     """

--- a/pql/matching.py
+++ b/pql/matching.py
@@ -117,6 +117,7 @@ class FieldName(AstHandler):
         return name.id
     def handle_Attribute(self, attr):
         return '{0}.{1}'.format(self.handle(attr.value), attr.attr)
+    
 
 class OperatorMap(object):
     def resolve_field(self, node):
@@ -366,6 +367,15 @@ class StringField(AlgebricField):
     def handle_Str(self, node):
         return node.s
 
+class ConstantField(AlgebricField):  
+    """
+    Converting constants into a string (ast parser assigns a value of "Constant" to quoted strings and constant numeric values to the right
+    and lef part of comparison expression(comparison operators). for handling these constants we convert this constant into a string.
+    adding a ConsatntField handler class which we pass in a GenericField class)
+    """
+    def handle_Constant(self, node):
+        return node.s        
+
 class IntField(AlgebricField):
     def handle_Num(self, node):
         return node.n
@@ -424,6 +434,6 @@ class IdField(AlgebricField):
     def handle_Call(self, node):
         return IdFunc().handle(node)
 
-class GenericField(IntField, BoolField, StringField, ListField, DictField, GeoField):
+class GenericField(IntField, BoolField, StringField, ListField, DictField, GeoField,ConstantField):
     def handle_Call(self, node):
         return GenericFunc().handle(node)


### PR DESCRIPTION
The Python ast module, which this library depends on has been changed in more recent versions of Python. For sure 3.8, and possibly 3.7 or earlier. The ast parser assigns a value of "Constant" to quoted strings and constant numeric values to the right and left side of the comparison operator inside a comparison expression. When this is not handled by the resolve() function inside a AstHandler class as  the string "Constant" is appended to "handle_" and then the getattr() method fails because none of the field handler functions have a handle_Constant() function.
So i have added the handle_Constant() function inside a ConstantField class and pass this class as argument inside GenericField class. This handle_constant () function converts constants into a string. 

So with this we are able to convert python expression to a pymongo expression even with python versions greater than 3.7